### PR TITLE
fix: pass `transferable` constructor via arguments

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -22,14 +22,14 @@
   verbosity = 4
 
 [etherscan]
-  arbitrum_one = { key = "${API_KEY_ARBISCAN}" }
-  avalanche = { key = "${API_KEY_SNOWTRACE}" }
-  bnb_smart_chain = { key = "${API_KEY_BSCSCAN}" }
-  gnosis_chain = { key = "${API_KEY_GNOSISSCAN}" }
-  goerli = { key = "${API_KEY_ETHERSCAN}" }
-  mainnet = { key = "${API_KEY_ETHERSCAN}" }
-  optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
-  polygon = { key = "${API_KEY_POLYGONSCAN}" }
+  # arbitrum_one = { key = "${API_KEY_ARBISCAN}" }
+  # avalanche = { key = "${API_KEY_SNOWTRACE}" }
+  # bnb_smart_chain = { key = "${API_KEY_BSCSCAN}" }
+  # gnosis_chain = { key = "${API_KEY_GNOSISSCAN}" }
+  # goerli = { key = "${API_KEY_ETHERSCAN}" }
+  # mainnet = { key = "${API_KEY_ETHERSCAN}" }
+  # optimism = { key = "${API_KEY_OPTIMISTIC_ETHERSCAN}" }
+  # polygon = { key = "${API_KEY_POLYGONSCAN}" }
   sepolia = { key = "${API_KEY_ETHERSCAN}" }
 
 [fmt]
@@ -43,13 +43,13 @@
   wrap_comments = true
 
 [rpc_endpoints]
-  arbitrum_one = "https://arbitrum-mainnet.infura.io/v3/${API_KEY_INFURA}"
-  avalanche = "https://avalanche-mainnet.infura.io/v3/${API_KEY_INFURA}"
-  bnb_smart_chain = "https://bsc-dataseed.binance.org"
-  gnosis_chain = "https://rpc.gnosischain.com"
-  goerli = "https://goerli.infura.io/v3/${API_KEY_INFURA}"
-  localhost = "http://localhost:8545"
-  mainnet = "https://eth-mainnet.g.alchemy.com/v2/${API_KEY_ALCHEMY}"
-  optimism = "https://optimism-mainnet.infura.io/v3/${API_KEY_INFURA}"
-  polygon = "https://polygon-mainnet.infura.io/v3/${API_KEY_INFURA}"
-  sepolia = "https://sepolia.infura.io/v3/${API_KEY_INFURA}"
+  # arbitrum_one = "https://arbitrum-mainnet.infura.io/v3/${API_KEY_INFURA}"
+  # avalanche = "https://avalanche-mainnet.infura.io/v3/${API_KEY_INFURA}"
+  # bnb_smart_chain = "https://bsc-dataseed.binance.org"
+  # gnosis_chain = "https://rpc.gnosischain.com"
+  # goerli = "https://goerli.infura.io/v3/${API_KEY_INFURA}"
+  # localhost = "http://localhost:8545"
+  # mainnet = "https://eth-mainnet.g.alchemy.com/v2/${API_KEY_ALCHEMY}"
+  # optimism = "https://optimism-mainnet.infura.io/v3/${API_KEY_INFURA}"
+  # polygon = "https://polygon-mainnet.infura.io/v3/${API_KEY_INFURA}"
+  sepolia = "https://eth-sepolia.g.alchemy.com/v2/${API_KEY_SEPOLIA}"

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -14,7 +14,7 @@ contract Deploy is BaseScript {
             deploymentConfig.activeNetworkConfig();
 
         vm.startBroadcast(broadcaster);
-        SNTV2 sntV2 = new SNTV2(tokenName, decimalUnits, tokenSymbol);
+        SNTV2 sntV2 = new SNTV2(tokenName, decimalUnits, tokenSymbol, true);
         SNTTokenController controller = new SNTTokenController(payable(address(sntV2)), false);
         sntV2.changeController(payable(address(controller)));
         vm.stopBroadcast();

--- a/src/SNTV2.sol
+++ b/src/SNTV2.sol
@@ -7,8 +7,9 @@ contract SNTV2 is MiniMeToken {
     constructor(
         string memory _tokenName,
         uint8 _decimalUnits,
-        string memory _tokenSymbol
+        string memory _tokenSymbol,
+        bool _transferable
     )
-        MiniMeToken(MiniMeToken(payable(address(0))), 0, _tokenName, _decimalUnits, _tokenSymbol, true)
+        MiniMeToken(MiniMeToken(payable(address(0))), 0, _tokenName, _decimalUnits, _tokenSymbol, _transferable)
     { }
 }


### PR DESCRIPTION
It seems foundry is unable to decode a hardcoded constructor argument when running deployment scripts.

So this commit passes the value to the constructor during instantiation.

Also comments out etherscan configurations we aren't using at the moment. Without removing/commenting them out, foundry will complain if they don't have valid values.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
- [x] Ran `pnpm verify`?
